### PR TITLE
Leaderboards Mvp

### DIFF
--- a/examples/leaderboard.rs
+++ b/examples/leaderboard.rs
@@ -1,0 +1,32 @@
+use nakama_rs::{
+    api_client::ApiClient,
+    config,
+};
+
+fn main() {
+    let mut client = ApiClient::new("defaultkey", "127.0.0.1", config::DEFAULT_PORT, "http");
+
+    client.register("email@provider.com", "password", "Leader");
+
+    while client.in_progress() {
+        client.tick()
+    }
+
+    client.write_leaderboard_record("wins", 1);
+
+    while client.in_progress() {
+        client.tick()
+    }
+
+    client.list_leaderboard_records("wins");
+
+    while client.in_progress() {
+        client.tick()
+    }
+
+    if let Some(leaderboard) = client.leaderboard_records("wins") {
+        for record in &leaderboard.records {
+            println!("{:?}", record);
+        }
+    }
+}

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -6,11 +6,8 @@ fn main() {
     // Note that the minimum password length is 8 characters!
     client.register("some@user.com", "password", "Username");
 
-    loop {
-        client.tick();
-        if !client.in_progress() {
-            break
-        }
+    while client.in_progress() {
+        client.tick()
     }
 
     println!("Username: {:?}", client.username());

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -107,7 +107,7 @@ impl ApiClient {
     }
 
     pub fn in_progress(&self) -> bool {
-        self.ongoing_request.is_some()
+        self.ongoing_request.is_some() || self.state.borrow().next_request.is_some()
     }
 
     pub fn authenticate(&mut self, email: &str, password: &str) {


### PR DESCRIPTION
A minimal implementation of the API needed by fishgame.

Also includes two minor improvements:
- Add default implementation of ApiClient to simplify example setup
- Simplify tick loops by changing how `in_progress` is computed